### PR TITLE
ci(publish): fix passing secrets to reusable workflow

### DIFF
--- a/.github/workflows/publish-2.7.yml
+++ b/.github/workflows/publish-2.7.yml
@@ -1,4 +1,4 @@
-name: publish
+name: publish-2.7
 
 on:
   push:
@@ -32,3 +32,5 @@ jobs:
       version: ${{ matrix.image.version }}
       variant: ${{ matrix.image.variant }}
       tags: ${{ matrix.image.tags }}
+    secrets:
+      password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/publish-3.12.yml
+++ b/.github/workflows/publish-3.12.yml
@@ -1,4 +1,4 @@
-name: publish
+name: publish-3.12
 
 on:
   push:
@@ -61,3 +61,5 @@ jobs:
       version: ${{ matrix.image.version }}
       variant: ${{ matrix.image.variant }}
       tags: ${{ matrix.image.tags }}
+    secrets:
+      password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,6 +16,9 @@ on:
           List of tags as key-value pair attributes.
         required: false
         type: string
+    secrets:
+      password:
+        required: true
 
 jobs:
   publish:
@@ -29,4 +32,4 @@ jobs:
       build-cache-key: ${{ inputs.version }}-${{ inputs.variant }}
       build-digest-key: ${{ inputs.version }}-${{ inputs.variant }}
     secrets:
-      registry-password: ${{ secrets.DOCKERHUB_TOKEN }}
+      registry-password: ${{ secrets.password }}


### PR DESCRIPTION
secrets, other than GITHUB_TOKEN, were not available
